### PR TITLE
Add billingOptions type and availableCountries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add billingOptions type and availableCountries
+
 ## [1.0.4] - 2020-07-01
 ### Fixed
 - Markdown ordered lists on `full_description.txt`

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,9 @@
     "support": {
       "url": "https://support.vtex.com/hc/requests"
     },
-    "free": true
+    "free": true,
+    "type": "free",
+    "availableCountries": ["*"]
   },
   "builders": {
     "react": "3.x",


### PR DESCRIPTION
**What problem is this solving?**

<!--- What is the motivation and context for this change? -->

https://github.com/vtex/node-vtex-api/pull/390 introduced a new `billingOptions` format. While we prepare all existing apps to that new format, we're temporarily supporting a `billingOptions` format that is a valid legacy billingOptions but also has valid property names and values for the new format.

This PR adds the correspondent missing properties in the new billingOptions format (`type` and `availableCountries`)

**How should this be manually tested?**

This modification should not change the behavior of the app

**Screenshots or example usage:**