### PR TITLE
Inline badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Support for inline badge block `google-customer-review-badge`.
+
 ## [1.0.7] - 2020-11-10
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
     "docs": "0.x"
   },
   "dependencies": {
-    "vtex.pixel-interfaces": "1.x"
+    "vtex.pixel-interfaces": "1.x",
+    "vtex.css-handles": "1.x"
   },
   "settingsSchema": {
     "title": "Google Customer Reviews",

--- a/react/Badge.tsx
+++ b/react/Badge.tsx
@@ -1,38 +1,34 @@
-import React, { useRef } from 'react'
-import { useRuntime } from 'vtex.render-runtime'
+import React, { useEffect } from 'react'
+
+import { addScript } from './modules/addScript'
+
+// @ts-expect-error it will be called onload of the script
+window.renderGoogleInlineBadge = function() {
+  var ratingBadgeContainer = document.getElementById(
+    'google-customer-reviews-badge'
+  ) as HTMLDivElement
+
+  window.gapi.load('ratingbadge', function() {
+    const merchantId = window.__google_customer_reviews
+      ? window.__google_customer_reviews.merchantId
+      : ''
+
+    if (!ratingBadgeContainer) return
+
+    window.gapi.ratingbadge.render(ratingBadgeContainer, {
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      merchant_id: merchantId,
+      position: 'INLINE',
+    })
+  })
+}
 
 function Badge() {
-  const {
-    culture: { language },
-  } = useRuntime()
+  useEffect(() => {
+    addScript('renderGoogleInlineBadge')
+  }, [])
 
-  const languageSet = useRef<boolean>(false)
-
-  const merchantId = window.__google_customer_reviews
-    ? window.__google_customer_reviews.merchantId
-    : ''
-
-  if (!languageSet || languageSet.current === false) {
-    // @ts-expect-error as expected by their docs https://support.google.com/merchants/answer/7105655?hl=en&ref_topic=7105160
-    window.___gcfg = { lang: language }
-    languageSet.current = true
-  }
-
-  if (!merchantId) {
-    return null
-  }
-
-  return (
-    <>
-      <script src="https://apis.google.com/js/platform.js" async defer></script>
-
-      <div
-        dangerouslySetInnerHTML={{
-          __html: `<g:ratingbadge merchant_id=${merchantId}></g:ratingbadge>​`,
-        }}
-      ></div>
-    </>
-  )
+  return <div id="google-customer-reviews-badge"></div>
 }
 
 export default Badge

--- a/react/Badge.tsx
+++ b/react/Badge.tsx
@@ -1,20 +1,37 @@
-import React, { FC } from 'react'
+import React, { useRef } from 'react'
+import { useRuntime } from 'vtex.render-runtime'
 
-const Badge: FC = () => {
+function Badge() {
+  const {
+    culture: { language },
+  } = useRuntime()
+
+  const languageSet = useRef<boolean>(false)
+
   const merchantId = window.__google_customer_reviews
     ? window.__google_customer_reviews.merchantId
     : ''
+
+  if (!languageSet || languageSet.current === false) {
+    // @ts-expect-error as expected by their docs https://support.google.com/merchants/answer/7105655?hl=en&ref_topic=7105160
+    window.___gcfg = { lang: language }
+    languageSet.current = true
+  }
 
   if (!merchantId) {
     return null
   }
 
   return (
-    <div
-      dangerouslySetInnerHTML={{
-        __html: `<g:ratingbadge merchant_id=${merchantId}></g:ratingbadge>​`,
-      }}
-    ></div>
+    <>
+      <script src="https://apis.google.com/js/platform.js" async defer></script>
+
+      <div
+        dangerouslySetInnerHTML={{
+          __html: `<g:ratingbadge merchant_id=${merchantId}></g:ratingbadge>​`,
+        }}
+      ></div>
+    </>
   )
 }
 

--- a/react/Badge.tsx
+++ b/react/Badge.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { useCssHandles } from 'vtex.css-handles'
 
 import { addScript } from './modules/addScript'
 
@@ -23,12 +24,18 @@ window.renderGoogleInlineBadge = function() {
   })
 }
 
+const CSS_HANDLES = ['badge'] as const
+
 function Badge() {
+  const { handles } = useCssHandles(CSS_HANDLES)
+
   useEffect(() => {
     addScript('renderGoogleInlineBadge')
   }, [])
 
-  return <div id="google-customer-reviews-badge"></div>
+  return (
+    <div id="google-customer-reviews-badge" className={handles.badge}></div>
+  )
 }
 
 export default Badge

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -2,14 +2,7 @@
 import { canUseDOM } from 'vtex.render-runtime'
 import { PixelMessage } from './typings/events'
 import { getCountryISO2 } from './modules/iso-3-to-2'
-
-function addScript() {
-  const script = document.createElement('script')
-  script.async = true
-  script.defer = true
-  script.src = 'https://apis.google.com/js/platform.js?onload=renderOptIn'
-  document.body.appendChild(script)
-}
+import { addScript } from './modules/addScript'
 
 export function handleEvents(e: PixelMessage) {
   switch (e.data.eventName) {
@@ -62,7 +55,8 @@ export function handleEvents(e: PixelMessage) {
         })
       }
 
-      addScript()
+      addScript('renderOptIn')
+      return
     }
     default: {
       return

--- a/react/modules/addScript.ts
+++ b/react/modules/addScript.ts
@@ -1,0 +1,11 @@
+export function addScript(callbackName: string) {
+  const scriptOnPage = document.getElementById('google-customer-reviews')
+  if (scriptOnPage) return
+
+  const script = document.createElement('script')
+  script.async = true
+  script.defer = true
+  script.id = 'google-customer-reviews'
+  script.src = 'https://apis.google.com/js/platform.js?onload=' + callbackName
+  document.body.appendChild(script)
+}

--- a/react/package.json
+++ b/react/package.json
@@ -22,7 +22,9 @@
     "prettier": "^1.18.2",
     "react-intl": "^3.11.0",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7",
+    "vtex.pixel-interfaces": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-interfaces@1.1.1/public/_types/react",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime"
   },
   "version": "1.0.6"
 }

--- a/react/package.json
+++ b/react/package.json
@@ -23,6 +23,7 @@
     "react-intl": "^3.11.0",
     "tslint-eslint-rules": "^5.4.0",
     "typescript": "3.9.7",
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles",
     "vtex.pixel-interfaces": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-interfaces@1.1.1/public/_types/react",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime"
   },

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -1,3 +1,0 @@
-declare module 'vtex.render-runtime' {
-  export const canUseDOM: boolean
-}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5084,10 +5084,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.7.3:
   version "3.7.5"
@@ -5193,6 +5193,14 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+"vtex.pixel-interfaces@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-interfaces@1.1.1/public/_types/react":
+  version "0.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-interfaces@1.1.1/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime":
+  version "8.126.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime#40d7ad8a7b04c50e61ff84a1089dcf7045efd548"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5194,6 +5194,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles":
+  version "1.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles#336b23ef3a9bcb2b809529ba736783acd405d081"
+
 "vtex.pixel-interfaces@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-interfaces@1.1.1/public/_types/react":
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-interfaces@1.1.1/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"


### PR DESCRIPTION
**What problem is this solving?**

Fixes https://github.com/vtex-apps/store-discussion/issues/502

Merchant ID of store-theme: 139401789

**How should this be manually tested?**

1. Add the app to your theme peerDependency (this will require a new major version, update the app theme settings with this [tutorial](https://vtex.io/docs/recipes/development/migrating-CMS-settings-after-major-update)):

```diff
   "peerDependencies": {
     "vtex.reviews-and-ratings": "2.x",
+    "vtex.google-customer-reviews": "1.x"
   },
```

2. Add the block to your theme:

```diff
   "flex-layout.row#footer-1-desktop": {
     "children": [
       "vtex.menu@2.x:menu#Products",
       "vtex.menu@2.x:menu#footer-clothing",
       "vtex.menu@2.x:menu#footer-decoration",
       "vtex.menu@2.x:menu#footer-bags",
       "footer-spacer",
       "social-networks",
+      "google-customer-review-badge"
     ],
     "props": {
       "blockClass": "menu-row",
       "paddingTop": 6,
       "paddingBottom": 3
     }
   },
```

https://storetheme.vtex.com/?workspace=customer

**Screenshots or example usage:**

It would should up here, but our account in Merchant Center is disabled:

![image](https://user-images.githubusercontent.com/284515/102536412-56beb200-4088-11eb-967b-155285f5b612.png)


